### PR TITLE
New Rule: implicit_case_default -- basic implementation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2032,6 +2032,89 @@ The most relevant clauses of IEEE1800-2017 are:
 
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
+## Syntax Rule: `implicit_case_default`
+
+### Hint
+
+Signal driven in `case` statement does not have a default value.
+
+### Reason
+
+Default values ensure that signals are always driven.
+
+### Pass Example (1 of 2)
+```systemverilog
+module M;
+  always_comb
+    y = 0;
+    case(x)
+      1: y = 1; // case default is implicit
+    endcase
+endmodule
+```
+
+### Pass Example (2 of 2)
+```systemverilog
+module M;
+  always_comb
+    case(x)
+      1: y = 1;
+      default: y = 0;
+    endcase
+endmodule
+```
+
+### Fail Example (1 of 2)
+```systemverilog
+module M;
+  always_comb
+    case (x)
+      1: a = 0; // No implicit or explicit case default
+    endcase
+endmodule
+```
+
+### Fail Example (2 of 2)
+```systemverilog
+module M;
+  always_comb begin
+    a = 0;
+
+    case(x)
+      1: b = 0;
+    endcase
+  end
+endmodule
+```
+
+### Explanation
+
+This rule is an extension of the **case_default** rule that allows the case default to be implicitly defined.
+Case statements without a `default` branch can cause signals to be undriven. Setting default values of signals at the top of an `always` procedures is good practice and ensures that signals are never metastable when a case match fails. For example,
+```sv
+always_comb begin
+  y = 0;
+  case(x)
+    1: y = 1;
+  endcase
+end
+
+```
+If the case match fails, `y` wouldn't infer memory or be undriven because the default value is defined before the `case`.
+
+See also:
+ - **case_default**
+ - **explicit_case_default**
+
+The most relevant clauses of IEEE1800-2017 are:
+
+- 12.5 Case statement
+
+
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Syntax Rule: `inout_with_tri`
 
 ### Hint

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -1,0 +1,92 @@
+use crate::config::ConfigOption;
+use crate::linter::{SyntaxRule, SyntaxRuleResult};
+use sv_parser::{unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
+
+#[derive(Default)]
+pub struct ImplicitCaseDefault {
+    under_always_construct: bool,
+    lhs_variables: Vec<String>,
+}
+
+impl SyntaxRule for ImplicitCaseDefault {
+    fn check(
+        &mut self,
+        syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _option: &ConfigOption,
+    ) -> SyntaxRuleResult {
+        // println!("Syntax Tree: {}", syntax_tree);
+
+        let node = match event {
+            NodeEvent::Enter(x) => {
+                match x {
+                    RefNode::AlwaysConstruct(_) => {
+                        self.under_always_construct = true;
+                    }
+
+                    RefNode::BlockItemDeclaration(x) => {
+                        let var = unwrap_node!(*x, VariableDeclAssignment).unwrap();
+                        let id = get_identifier(var);
+                        let id = syntax_tree.get_str(&id).unwrap();
+
+                        self.lhs_variables.push(String::from(id));
+
+                        println!("LHS Variables: {:?}", self.lhs_variables);
+                    }
+
+                    _ => (),
+                }
+                x
+            }
+            NodeEvent::Leave(x) => {
+                if let RefNode::AlwaysConstruct(_) = x {
+                    self.under_always_construct = false;
+                }
+                return SyntaxRuleResult::Pass;
+            }
+        };
+        match (self.under_always_construct, node) {
+            (true, RefNode::CaseStatementNormal(x)) => {
+                let a = unwrap_node!(*x, CaseItemDefault);
+                if a.is_some() {
+                    SyntaxRuleResult::Pass
+                } else {
+                    // check if lvalues of case statement have an implicit definition
+                    let var = unwrap_node!(*x, VariableLvalueIdentifier).unwrap();
+                    let id = get_identifier(var);
+                    let id = syntax_tree.get_str(&id).unwrap();
+
+                    println!("Case variable: {id}");
+
+                    // check if id is in lhs_variables
+                    if self.lhs_variables.contains(&id.to_string()) {
+                        SyntaxRuleResult::Pass
+                    } else {
+                        SyntaxRuleResult::Fail
+                    }
+                }
+            }
+            _ => SyntaxRuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("implicit_case_default")
+    }
+
+    fn hint(&self, _option: &ConfigOption) -> String {
+        String::from("Signal driven in `case` statement does not have a default value.")
+    }
+
+    fn reason(&self) -> String {
+        String::from("Default values ensure that signals are always driven.")
+    }
+}
+
+fn get_identifier(node: RefNode) -> Option<Locate> {
+    match unwrap_node!(node, SimpleIdentifier, EscapedIdentifier) {
+        Some(RefNode::SimpleIdentifier(x)) => Some(x.nodes.0),
+        Some(RefNode::EscapedIdentifier(x)) => Some(x.nodes.0),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Implementation for `implicit_case_default` rule.
- Create a list of all LHS variables when you enter an `always` block
- Check whether case statement has an explicit `default` arm --> pass
- Else, check if variable in case statement has been previously assigned to, by looking at LHS variable list

## TODO
- Need to test cases where multiple signals are driven in the case
- Make sure that only the signals under the `always` block are added to LHS vars list

## Relevant Issues
- https://github.com/dalance/svlint/issues/268