### PR TITLE
New Rule: implicit case default -- updated implementation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2037,7 +2037,6 @@ The most relevant clauses of IEEE1800-2017 are:
 ### Hint
 
 Signal driven in `case` statement does not have a default value.
- Define a default case or implicitly define before `case` statement.
 
 ### Reason
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2036,7 +2036,8 @@ The most relevant clauses of IEEE1800-2017 are:
 
 ### Hint
 
-Signal driven in `case` statement does not have a default value. Define a default case or implicitly define before `case` statement.
+Signal driven in `case` statement does not have a default value.
+ Define a default case or implicitly define before `case` statement.
 
 ### Reason
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2082,7 +2082,7 @@ module M;
 endmodule
 ```
 
-### Fail Example (1 of 2)
+### Fail Example (1 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2092,7 +2092,23 @@ module M;
 endmodule
 ```
 
-### Fail Example (2 of 2)
+### Fail Example (2 of 3)
+```systemverilog
+module M;
+  always_comb begin
+    y = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+```
+
+### Fail Example (3 of 3)
 ```systemverilog
 module M;
   always_comb begin

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2036,13 +2036,13 @@ The most relevant clauses of IEEE1800-2017 are:
 
 ### Hint
 
-Signal driven in `case` statement does not have a default value.
+Signal driven in `case` statement does not have a default value. Define a default case or implicitly define before `case` statement.
 
 ### Reason
 
 Default values ensure that signals are always driven.
 
-### Pass Example (1 of 2)
+### Pass Example (1 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2053,7 +2053,25 @@ module M;
 endmodule
 ```
 
-### Pass Example (2 of 2)
+### Pass Example (2 of 3)
+```systemverilog
+module M;
+  always_comb begin
+    y = 0;
+    z = 0;
+    w = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+```
+
+### Pass Example (3 of 3)
 ```systemverilog
 module M;
   always_comb
@@ -2079,7 +2097,6 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-
     case(x)
       1: b = 0;
     endcase

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -5,7 +5,8 @@ use sv_parser::{unwrap_node, Locate, NodeEvent, RefNode, SyntaxTree};
 #[derive(Default)]
 pub struct ImplicitCaseDefault {
     under_always_construct: bool,
-    lhs_variables: Vec<String>,
+    implicit_variables: Vec<String>,
+    case_variables: Vec<String>,
 }
 
 impl SyntaxRule for ImplicitCaseDefault {
@@ -29,9 +30,9 @@ impl SyntaxRule for ImplicitCaseDefault {
                         let id = get_identifier(var);
                         let id = syntax_tree.get_str(&id).unwrap();
 
-                        self.lhs_variables.push(String::from(id));
+                        self.implicit_variables.push(String::from(id));
 
-                        println!("LHS Variables: {:?}", self.lhs_variables);
+                        println!("LHS Variables: {:?}", self.implicit_variables);
                     }
 
                     _ => (),
@@ -58,8 +59,8 @@ impl SyntaxRule for ImplicitCaseDefault {
 
                     println!("Case variable: {id}");
 
-                    // check if id is in lhs_variables
-                    if self.lhs_variables.contains(&id.to_string()) {
+                    // check if id is in implicit_variables
+                    if self.implicit_variables.contains(&id.to_string()) {
                         SyntaxRuleResult::Pass
                     } else {
                         SyntaxRuleResult::Fail

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -114,7 +114,7 @@ impl SyntaxRule for ImplicitCaseDefault {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from("Signal driven in `case` statement does not have a default value.\n Define a default case or implicitly define before `case` statement.")
+        String::from("Signal driven in `case` statement does not have a default value.")
     }
 
     fn reason(&self) -> String {

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -19,8 +19,6 @@ impl SyntaxRule for ImplicitCaseDefault {
         event: &NodeEvent,
         _option: &ConfigOption,
     ) -> SyntaxRuleResult {
-        //println!("{}", syntax_tree);
-
         let node = match event {
             NodeEvent::Enter(x) => {
                 match x {
@@ -57,8 +55,6 @@ impl SyntaxRule for ImplicitCaseDefault {
                 return SyntaxRuleResult::Pass;
             }
         };
-
-        //println!("{}", node);
 
         // match implicit declarations
         match (self.under_always_construct, self.under_case_item, node) {

--- a/src/syntaxrules/implicit_case_default.rs
+++ b/src/syntaxrules/implicit_case_default.rs
@@ -9,7 +9,6 @@ pub struct ImplicitCaseDefault {
     is_default: bool,
 
     lhs_variables: Vec<String>,
-    case_variables: Vec<String>
 }
 
 impl SyntaxRule for ImplicitCaseDefault {
@@ -42,8 +41,6 @@ impl SyntaxRule for ImplicitCaseDefault {
                         self.under_always_construct = false;
                         self.is_default = false;
                         self.lhs_variables.clear();
-                        self.case_variables.clear();
-
                     }
 
                     RefNode::CaseItemNondefault(_) => {
@@ -117,7 +114,7 @@ impl SyntaxRule for ImplicitCaseDefault {
     }
 
     fn hint(&self, _option: &ConfigOption) -> String {
-        String::from("Signal driven in `case` statement does not have a default value. Define a default case or implicitly define before `case` statement.")
+        String::from("Signal driven in `case` statement does not have a default value.\n Define a default case or implicitly define before `case` statement.")
     }
 
     fn reason(&self) -> String {

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -7,6 +7,19 @@ endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
   always_comb begin
+    y = 0;
+    case(x)
+      1: y = 1;
+      2: begin 
+        z = 1;
+        w = 1;
+      end
+    endcase
+  end
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb begin
     a = 0;
     case(x)
       1: b = 0;

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -8,7 +8,6 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-
     case(x)
       1: b = 0;
     endcase

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -1,14 +1,30 @@
 module M;
+  always_comb
+    y = 0;
+    case(x)
+      1: y = 1; // case default is implicit
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
   always_comb begin
     y = 0;
     z = 0;
-    //w = 0;
+    w = 0;
     case(x)
-      1: y = 1; // case default is implicit
+      1: y = 1;
       2: begin 
         z = 1;
         w = 1;
       end
     endcase
   end
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb
+    case(x)
+      1: y = 1;
+      default: y = 0;
+    endcase
 endmodule

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -1,15 +1,14 @@
 module M;
-  always_comb
+  always_comb begin
     y = 0;
+    z = 0;
+    //w = 0;
     case(x)
       1: y = 1; // case default is implicit
+      2: begin 
+        z = 1;
+        w = 1;
+      end
     endcase
-endmodule
-////////////////////////////////////////////////////////////////////////////////
-module M;
-  always_comb
-    case(x)
-      1: y = 1;
-      default: y = 0;
-    endcase
+  end
 endmodule


### PR DESCRIPTION
## Updated Implementation

- Populates a list of LHS variables once encountered in ```always``` construct block
- Checks if default case exists and sets bool to ```true```
- Goes through each declaration within case item and compares with LHS variable list
- If does not exist, return ```fail```, but if default exists, return ```pass```, otherwise, return ```fail```

## Relevant Issues

- dalance/svlint#268