### PR TITLE
Minor changes to implicit_case_default

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2040,16 +2040,17 @@ Signal driven in `case` statement does not have a default value.
 
 ### Reason
 
-Default values ensure that signals are always driven.
+Default values ensure that signals are never metastable.
 
 ### Pass Example (1 of 3)
 ```systemverilog
 module M;
-  always_comb
+  always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1; // case default is implicit
     endcase
+  end
 endmodule
 ```
 
@@ -2060,9 +2061,9 @@ module M;
     y = 0;
     z = 0;
     w = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -2075,7 +2076,7 @@ endmodule
 ```systemverilog
 module M;
   always_comb
-    case(x)
+    case (x)
       1: y = 1;
       default: y = 0;
     endcase
@@ -2097,9 +2098,9 @@ endmodule
 module M;
   always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -2113,7 +2114,7 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-    case(x)
+    case (x)
       1: b = 0;
     endcase
   end

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2042,7 +2042,7 @@ Signal driven in `case` statement does not have a default value.
 
 Default values ensure that signals are never metastable.
 
-### Pass Example (1 of 3)
+### Pass Example (1 of 5)
 ```systemverilog
 module M;
   always_comb begin
@@ -2054,7 +2054,7 @@ module M;
 endmodule
 ```
 
-### Pass Example (2 of 3)
+### Pass Example (2 of 5)
 ```systemverilog
 module M;
   always_comb begin
@@ -2072,7 +2072,7 @@ module M;
 endmodule
 ```
 
-### Pass Example (3 of 3)
+### Pass Example (3 of 5)
 ```systemverilog
 module M;
   always_comb
@@ -2080,6 +2080,37 @@ module M;
       1: y = 1;
       default: y = 0;
     endcase
+endmodule
+```
+
+### Pass Example (4 of 5)
+```systemverilog
+module M;
+  always_comb
+    case (x)
+      1: p = 1;
+      2: q = 0;
+      default: begin
+        p = 0;
+        q = 0;
+      end
+    endcase
+endmodule
+```
+
+### Pass Example (5 of 5)
+```systemverilog
+module M;
+  always_comb begin
+    p = 0;  // p -> implicit default
+    q = 0;  // q -> implicit default
+    case (x)
+      1: p = 1;
+      2: q = 1;
+      3: r = 1;
+      default: r = 1; // r -> explicit default
+    endcase
+  end
 endmodule
 ```
 

--- a/testcases/syntaxrules/fail/implicit_case_default.sv
+++ b/testcases/syntaxrules/fail/implicit_case_default.sv
@@ -8,9 +8,9 @@ endmodule
 module M;
   always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -21,7 +21,7 @@ endmodule
 module M;
   always_comb begin
     a = 0;
-    case(x)
+    case (x)
       1: b = 0;
     endcase
   end

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -1,9 +1,10 @@
 module M;
-  always_comb
+  always_comb begin
     y = 0;
-    case(x)
+    case (x)
       1: y = 1; // case default is implicit
     endcase
+  end
 endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
@@ -11,9 +12,9 @@ module M;
     y = 0;
     z = 0;
     w = 0;
-    case(x)
+    case (x)
       1: y = 1;
-      2: begin 
+      2: begin
         z = 1;
         w = 1;
       end
@@ -23,7 +24,7 @@ endmodule
 ////////////////////////////////////////////////////////////////////////////////
 module M;
   always_comb
-    case(x)
+    case (x)
       1: y = 1;
       default: y = 0;
     endcase

--- a/testcases/syntaxrules/pass/implicit_case_default.sv
+++ b/testcases/syntaxrules/pass/implicit_case_default.sv
@@ -29,3 +29,28 @@ module M;
       default: y = 0;
     endcase
 endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb
+    case (x)
+      1: p = 1;
+      2: q = 0;
+      default: begin
+        p = 0;
+        q = 0;
+      end
+    endcase
+endmodule
+////////////////////////////////////////////////////////////////////////////////
+module M;
+  always_comb begin
+    p = 0;  // p -> implicit default
+    q = 0;  // q -> implicit default
+    case (x)
+      1: p = 1;
+      2: q = 1;
+      3: r = 1;
+      default: r = 1; // r -> explicit default
+    endcase
+  end
+endmodule


### PR DESCRIPTION
- Changed `match` to `if let` to destructure single case
- Added some missing begin/ends
- Added locate on fail